### PR TITLE
Add camera names, OSC /clearcam, and configurable response curves

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,34 @@ g_num_cams = 8
 cam_ips = ['127.0.0.1']*g_num_cams
 cam_ports = [52381]*g_num_cams
 
+# Phil Rose: user-friendly camera names for display consistency.
+cam_names = [f'Camera {x+1}' for x in range(g_num_cams)]
+
 g_visca_relay_port = 10000  # currently hardwired
+
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+# Tune Xbox joystick sensitivity for smoother PTZ control.
+# Original values retained below for easy rollback.
+# ------------------------------------------------------------------
+
+# sensitivity_tables = {
+#     'pan': {'joy': [0, 0.15, 0.2, 0.3, 0.5, 0.8, 0.9, 1], 'cam': [0, 0, 1, 2, 6, 8, 12, 18]},
+#     'tilt': {'joy': [0, 0.15, 0.2, 0.3, 0.5, 0.8, 0.9, 1], 'cam': [0, 0, 1, 3, 6, 8, 12, 18]},
+#     'zoom': {'joy': [0, 0.15, 0.2, 0.3, 0.4, 0.5, 0.7, 1], 'cam': [0, 0, 1, 1, 1, 3, 5, 7]},
+#     'focus': {'joy': [0, 0.2, 0.3, 0.7, 1], 'cam': [0, 0, 2, 5, 7]},
+# }
+
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+# User-configurable PTZ response speed lists.
+# These are the editable camera speed values only; the leading zero
+# values and joystick breakpoints are handled in code.
+# ------------------------------------------------------------------
+g_pan_speeds = "1,1,3,5,7,9"
+g_tilt_speeds = "1,1,3,5,7,9"
+g_zoom_speeds = "1,1,1,3,5,7"
+g_focus_speeds = "2,5,7"
 
 sensitivity_tables = {
     'pan': {'joy': [0, 0.15, 0.2, 0.3, 0.5, 0.8, 0.9, 1], 'cam': [0, 0, 1, 2, 6,  8, 12, 18]},
@@ -32,44 +59,168 @@ g_dead_zone = None
 g_companion_page = 0
 g_companion_host = "127.0.0.1"
 
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+# Parse, validate, and apply comma-separated speed response lists.
+# ------------------------------------------------------------------
+def parse_speed_list(text, expected_count, max_value, label):
+    try:
+        values = [int(x.strip()) for x in text.split(',')]
+    except ValueError:
+        raise ValueError(f"{label} must contain only comma-separated whole numbers.")
+
+    if len(values) != expected_count:
+        raise ValueError(
+            f"{label} must contain exactly {expected_count} comma-separated values.\n"
+            f"Example: {'1,1,3,5,7,9' if expected_count == 6 else '2,5,7'}"
+        )
+
+    for value in values:
+        if value < 0 or value > max_value:
+            raise ValueError(f"{label} values must be between 0 and {max_value}.")
+
+    return values
+
+
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+#
+# The user edits only the camera speed values.
+# The joystick breakpoints and leading zero values remain fixed.
+#
+# Example:
+#   User enters: 1,1,3,5,7,9
+#
+# Resulting table:
+#   [0, 0, 1, 1, 3, 5, 7, 9]
+# ------------------------------------------------------------------
+
+def rebuild_sensitivity_tables():
+    global sensitivity_tables
+
+    pan = parse_speed_list(g_pan_speeds, 6, 24, "Pan Speeds")
+    tilt = parse_speed_list(g_tilt_speeds, 6, 24, "Tilt Speeds")
+    zoom = parse_speed_list(g_zoom_speeds, 6, 7, "Zoom Speeds")
+    focus = parse_speed_list(g_focus_speeds, 3, 7, "Focus Speeds")
+
+    sensitivity_tables = {
+        'pan':   {'joy': [0, 0.15, 0.2, 0.3, 0.5, 0.8, 0.9, 1], 'cam': [0, 0] + pan},
+        'tilt':  {'joy': [0, 0.15, 0.2, 0.3, 0.5, 0.8, 0.9, 1], 'cam': [0, 0] + tilt},
+        'zoom':  {'joy': [0, 0.15, 0.2, 0.3, 0.4, 0.5, 0.7, 1], 'cam': [0, 0] + zoom},
+        'focus': {'joy': [0, 0.2, 0.3, 0.7, 1], 'cam': [0, 0] + focus},
+    }
+
+
 def configure():
     """ Configuration dialog """
     global g_long_press_time, g_Debug, g_companion_page, g_companion_host, g_swap_pan, g_invert_tilt
     global g_dead_zone
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+#
+# Added globals to support changes
+# ------------------------------------------------------------------
+    global g_swap_pan, g_invert_tilt
+    global g_pan_speeds, g_tilt_speeds, g_zoom_speeds, g_focus_speeds
 
-    layout = [[Sg.Text("Camera", size=20), Sg.Text("Port")],
-              [Sg.Input(default_text=cam_ips[0], key='CAM1', size=20),
-               Sg.Input(default_text=str(cam_ports[0]), key='PORT1', size=8)],
-              [Sg.Input(default_text=cam_ips[1], key='CAM2', size=20),
-               Sg.Input(default_text=str(cam_ports[1]), key='PORT2', size=8)],
-              [Sg.Input(default_text=cam_ips[2], key='CAM3', size=20),
-               Sg.Input(default_text=str(cam_ports[2]), key='PORT3', size=8)],
-              [Sg.Input(default_text=cam_ips[3], key='CAM4', size=20),
-               Sg.Input(default_text=str(cam_ports[3]), key='PORT4', size=8)],
-              [Sg.Input(default_text=cam_ips[4], key='CAM5', size=20),
-               Sg.Input(default_text=str(cam_ports[4]), key='PORT5', size=8)],
-              [Sg.Input(default_text=cam_ips[5], key='CAM6', size=20),
-               Sg.Input(default_text=str(cam_ports[5]), key='PORT6', size=8)],
-              [Sg.Input(default_text=cam_ips[6], key='CAM7', size=20),
-               Sg.Input(default_text=str(cam_ports[6]), key='PORT7', size=8)],
-              [Sg.Input(default_text=cam_ips[7], key='CAM8', size=20),
-               Sg.Input(default_text=str(cam_ports[7]), key='PORT8', size=8)],
-              [Sg.Text('Long Press (restart required)'),
-                Sg.Input(default_text=str(g_long_press_time), key='-LONG-PRESS-', size=4),
-                Sg.Text('seconds')],
-              [Sg.Text('Joystick dead zone (restart required)'),
-               Sg.Input(default_text=str(g_dead_zone or ''), key='-DEAD-ZONE-', size=4)],
-              [Sg.Text('Bitfocus Companion Page '),
-               Sg.Input(default_text=str(g_companion_page), key='-COMPANION-PAGE-', size=4),
-               Sg.Text('Bitfocus Companion Host '),
-               Sg.Input(default_text=g_companion_host, key = '-COMPANION-HOST-', size = 15)],
-              [Sg.Checkbox('Invert Tilt', default=g_invert_tilt, key='-INVERT-TILT-'),
-                Sg.Checkbox('Swap Pan', default=g_swap_pan, key='-SWAP-PAN-'),
-                Sg.Checkbox('Debug Mode', default=g_Debug, key='-DEBUG-')],
-              [Sg.Button('Relay', tooltip='Fill in values for VISCA Relay'),
-               Sg.Button('Save'),
-               Sg.Button('Cancel')]
-              ]
+
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+# Reorganized Configure dialog into logical sections and added:
+# - Camera names
+# - Configurable PTZ response curves
+# - Companion integration help
+# ------------------------------------------------------------------
+
+    layout = [
+        [Sg.Text('Cameras', font=('Any', 10, 'bold'))],
+        [Sg.Text("Name", size=(15, 1)),
+        Sg.Text("IP Address", size=(20, 1)),
+        Sg.Text("Port", size=(8, 1))],
+
+        [Sg.Input(default_text=cam_names[0], key='NAME1', size=15),
+        Sg.Input(default_text=cam_ips[0], key='CAM1', size=20),
+        Sg.Input(default_text=str(cam_ports[0]), key='PORT1', size=8)],
+
+        [Sg.Input(default_text=cam_names[1], key='NAME2', size=15),
+        Sg.Input(default_text=cam_ips[1], key='CAM2', size=20),
+        Sg.Input(default_text=str(cam_ports[1]), key='PORT2', size=8)],
+
+        [Sg.Input(default_text=cam_names[2], key='NAME3', size=15),
+        Sg.Input(default_text=cam_ips[2], key='CAM3', size=20),
+        Sg.Input(default_text=str(cam_ports[2]), key='PORT3', size=8)],
+
+        [Sg.Input(default_text=cam_names[3], key='NAME4', size=15),
+        Sg.Input(default_text=cam_ips[3], key='CAM4', size=20),
+        Sg.Input(default_text=str(cam_ports[3]), key='PORT4', size=8)],
+
+        [Sg.Input(default_text=cam_names[4], key='NAME5', size=15),
+        Sg.Input(default_text=cam_ips[4], key='CAM5', size=20),
+        Sg.Input(default_text=str(cam_ports[4]), key='PORT5', size=8)],
+
+        [Sg.Input(default_text=cam_names[5], key='NAME6', size=15),
+        Sg.Input(default_text=cam_ips[5], key='CAM6', size=20),
+        Sg.Input(default_text=str(cam_ports[5]), key='PORT6', size=8)],
+
+        [Sg.Input(default_text=cam_names[6], key='NAME7', size=15),
+        Sg.Input(default_text=cam_ips[6], key='CAM7', size=20),
+        Sg.Input(default_text=str(cam_ports[6]), key='PORT7', size=8)],
+
+        [Sg.Input(default_text=cam_names[7], key='NAME8', size=15),
+        Sg.Input(default_text=cam_ips[7], key='CAM8', size=20),
+        Sg.Input(default_text=str(cam_ports[7]), key='PORT8', size=8)],
+
+        [Sg.HorizontalSeparator()],
+        [Sg.Text('Controller', font=('Any', 10, 'bold'))],
+        [Sg.Text('(Changes take effect after restart)', font=('Any', 10, 'italic'))],
+        [Sg.Text('Long Press'),
+        Sg.Input(default_text=str(g_long_press_time), key='-LONG-PRESS-', size=4),
+        Sg.Text('seconds')],
+
+        [Sg.Text('Joystick dead zone'),
+        Sg.Input(default_text=str(g_dead_zone or ''), key='-DEAD-ZONE-', size=4)],
+
+        [Sg.Checkbox('Invert Tilt', default=g_invert_tilt, key='-INVERT-TILT-'),
+        Sg.Checkbox('Swap Pan', default=g_swap_pan, key='-SWAP-PAN-'),
+        Sg.Checkbox('Debug Mode', default=g_Debug, key='-DEBUG-')],
+
+        # ------------------------------------------------------------------
+        # Phil Rose (2026-06-24)
+        # User-configurable response curves.
+        # ------------------------------------------------------------------
+        [Sg.HorizontalSeparator()],
+        [Sg.Text('Speed Profiles', font=('Any', 10, 'bold'))],
+        [Sg.Text('Comma-separated values. Higher numbers = faster movement.')],
+         
+        [Sg.Text('Pan Speeds', size=18),
+        Sg.Input(default_text=g_pan_speeds, key='-PAN-SPEEDS-', size=20),
+        Sg.Text('e.g. 1,1,3,5,7,9')],
+
+        [Sg.Text('Tilt Speeds', size=18),
+        Sg.Input(default_text=g_tilt_speeds, key='-TILT-SPEEDS-', size=20),
+        Sg.Text('e.g. 1,1,3,5,7,9')],
+
+        [Sg.Text('Zoom Speeds', size=18),
+        Sg.Input(default_text=g_zoom_speeds, key='-ZOOM-SPEEDS-', size=20),
+        Sg.Text('e.g. 1,1,1,3,5,7')],
+
+        [Sg.Text('Focus Speeds', size=18),
+        Sg.Input(default_text=g_focus_speeds, key='-FOCUS-SPEEDS-', size=20),
+        Sg.Text('e.g. 2,5,7')],
+
+        [Sg.HorizontalSeparator()],
+        [Sg.Text('Companion', font=('Any', 10, 'bold'))],
+        [Sg.Text('Bitfocus Companion Page '),
+        Sg.Input(default_text=str(g_companion_page), key='-COMPANION-PAGE-', size=4),
+        Sg.Text('Bitfocus Companion Host '),
+        Sg.Input(default_text=g_companion_host, key='-COMPANION-HOST-', size=15)],
+
+        [Sg.HorizontalSeparator()],
+        [Sg.Button('Relay', tooltip='Fill in values for VISCA Relay'),
+        Sg.Button('Save'),
+        Sg.Button('Cancel')]
+    ]
+
     window = Sg.Window(title='Configure', layout=layout, finalize=True, keep_on_top=True)
 
     while True:
@@ -84,11 +235,21 @@ def configure():
                 window['PORT'+str(x+1)].update(value=str(10000+x+1))
 
         elif event == 'Save':
+            
+            # ------------------------------------------------------------------
+            # Phil Rose (2026-06-24)
+            # Save user-configured camera names.
+            # ------------------------------------------------------------------
+
             for x in range(g_num_cams):
-                cam_ips[x] = values['CAM'+str(x+1)]
-                cam_ports[x] = int(values['PORT'+str(x+1)])
+                cam_names[x] = values['NAME' + str(x+1)] or f'Camera {x+1}'
+                cam_ips[x] = values['CAM' + str(x+1)]
+                cam_ports[x] = int(values['PORT' + str(x+1)])
+
+                Sg.user_settings_set_entry('-NAME' + str(x+1) + '-', cam_names[x])
                 Sg.user_settings_set_entry('-CAM' + str(x+1) + '-', cam_ips[x])
                 Sg.user_settings_set_entry('-PORT' + str(x+1) + '-', cam_ports[x])
+            # ------------------------
 
             try:
                 g_long_press_time = float(values['-LONG-PRESS-'])
@@ -102,6 +263,34 @@ def configure():
                 g_dead_zone = float(g_dead_zone)
             except ValueError:
                 g_dead_zone = None
+
+            
+            # ------------------------------------------------------------------
+            # Phil Rose (2026-06-24)
+            # Validate, save, and apply user-configurable response curves.
+            # ------------------------------------------------------------------
+            try:
+                parse_speed_list(values['-PAN-SPEEDS-'], 6, 24, "Pan Speeds")
+                parse_speed_list(values['-TILT-SPEEDS-'], 6, 24, "Tilt Speeds")
+                parse_speed_list(values['-ZOOM-SPEEDS-'], 6, 7, "Zoom Speeds")
+                parse_speed_list(values['-FOCUS-SPEEDS-'], 3, 7, "Focus Speeds")
+            except ValueError as exc:
+                Sg.popup(str(exc), title="Invalid Speed Settings", keep_on_top=True)
+                continue
+
+            g_pan_speeds = values['-PAN-SPEEDS-']
+            g_tilt_speeds = values['-TILT-SPEEDS-']
+            g_zoom_speeds = values['-ZOOM-SPEEDS-']
+            g_focus_speeds = values['-FOCUS-SPEEDS-']
+
+            Sg.user_settings_set_entry('-pan_speeds-', g_pan_speeds)
+            Sg.user_settings_set_entry('-tilt_speeds-', g_tilt_speeds)
+            Sg.user_settings_set_entry('-zoom_speeds-', g_zoom_speeds)
+            Sg.user_settings_set_entry('-focus_speeds-', g_focus_speeds)
+
+            rebuild_sensitivity_tables()
+             # ------------------------------------------------------------------
+           
             g_companion_page = int(values['-COMPANION-PAGE-'])
             g_companion_host = values['-COMPANION-HOST-']
             Sg.user_settings_set_entry('-long_press_time-', g_long_press_time)
@@ -125,10 +314,18 @@ def load_config():
     """ Load the saved configuration values at startup """
     global g_long_press_time, g_invert_tilt, g_swap_pan, g_companion_page
     global g_companion_host, g_Debug, g_dead_zone
+# Phil Rose (2026-06024 added globals)
+    global g_pan_speeds, g_tilt_speeds, g_zoom_speeds, g_focus_speeds
+
+    # ------------------------------------------------------------------
+    # Phil Rose (2026-06-24)
+    # Load user-configured camera names.
+    # ------------------------------------------------------------------
 
     for x in range(g_num_cams):
-        cam_ips[x] = Sg.user_settings_get_entry('-CAM'+str(x+1)+'-', '')
-        port = Sg.user_settings_get_entry('-PORT' + str(x + 1) + '-', 52381)
+        cam_names[x] = Sg.user_settings_get_entry('-NAME' + str(x+1) + '-', f'Camera {x+1}')
+        cam_ips[x] = Sg.user_settings_get_entry('-CAM' + str(x+1) + '-', '')
+        port = Sg.user_settings_get_entry('-PORT' + str(x+1) + '-', 52381)
         cam_ports[x] = port
 
     g_companion_page = Sg.user_settings_get_entry('-companion_page-', 99)
@@ -138,6 +335,19 @@ def load_config():
     g_swap_pan = Sg.user_settings_get_entry('-swap-pan-', False)
     g_Debug = Sg.user_settings_get_entry('-debug-', False)
     g_dead_zone = Sg.user_settings_get_entry('-dead-zone-', None)
+    
+    # ------------------------------------------------------------------
+    # Phil Rose (2026-06-24)
+    # Load saved user-configurable response curves.
+    # ------------------------------------------------------------------
+    g_pan_speeds = Sg.user_settings_get_entry('-pan_speeds-', g_pan_speeds)
+    g_tilt_speeds = Sg.user_settings_get_entry('-tilt_speeds-', g_tilt_speeds)
+    g_zoom_speeds = Sg.user_settings_get_entry('-zoom_speeds-', g_zoom_speeds)
+    g_focus_speeds = Sg.user_settings_get_entry('-focus_speeds-', g_focus_speeds)
+
+    
+    rebuild_sensitivity_tables()
+
     if not Sg.user_settings_get_entry('-configured-', False):
         configure()
 
@@ -212,6 +422,19 @@ class Config:
             return cam_ips[idx], cam_ports[idx]
         except IndexError:
             return None, 0
+
+    
+    # ------------------------------------------------------------------
+    # Phil Rose (2026-06-24)
+    # Return the configured display name for a camera.
+    # ------------------------------------------------------------------
+    @staticmethod
+    def cam_name(idx):
+        try:
+            return cam_names[idx]
+        except IndexError:
+            return f"Camera {idx+1}"
+    # ------------------------------------------------------------------
 
     @staticmethod
     def configure():

--- a/main.py
+++ b/main.py
@@ -33,6 +33,14 @@ if Windows and UsePsgTray:
 
 cam: Optional[Camera] = None
 current_cam = "Unknown"
+
+# ------------------------------------------------------------------
+# Phil Rose (2026-06-24)
+# Tracks whether the Xbox/gamepad should currently control PTZ.
+# /setcam enables this; /clearcam disables it for non-camera sources.
+# ------------------------------------------------------------------
+gamepad_enabled = True
+
 main_window:Optional[Sg.Window] = None
 config: Config = Config()
 bitfocus: Companion = Companion()
@@ -114,7 +122,12 @@ def connect_to_camera(cam_num) -> Optional[Camera]:
     if newcam is None:
         cam_name = "Unknown"
     else:
-        cam_name = str(cam_num)
+        # ------------------------------------------------------------------
+        # Phil Mod (2026-06-21)
+        # Display configured camera names instead of numeric identifiers.
+        # ------------------------------------------------------------------
+        cam_name = config.cam_name(cam_num - 1)
+
         # Bitfocus Companion (row 0, camera_number), should be configured to set Preview
         # to the selected camera
         bitfocus.pushbutton(* config.companion(0, cam_num))
@@ -138,7 +151,10 @@ def handle_select_cam(button: ControllerButton = None):
     Handle a button push to select a camera
     activates on button uup. Long press selects 2nd bank of cameras
     """
-    global cam
+    # Phil Rose - added gamepad_enabled
+    global cam, gamepad_enabled
+
+    gamepad_enabled = True
 
     if button is None or button.is_down:
         return
@@ -298,6 +314,27 @@ def handle_autofocus(button: ControllerButton):
     cam.set_focus_mode('auto')
     win_print("AutoFocus mode")
 
+# Phil Rose (2026-06-24)
+# Companion OSC command to explicitly disable PTZ control.
+def osc_clear_cam():
+    """
+    Handle the Companion /clearcam OSC command.
+
+    Disables gamepad PTZ control until another camera is selected
+    with /setcam.
+    """
+    global gamepad_enabled, current_cam
+
+    gamepad_enabled = False
+    current_cam = "No Active Camera"
+
+    win_print(current_cam)
+
+    if UsePsgTray:
+        tray = main_window.metadata
+        if tray is not None:
+            tray.set_tooltip(f"{config.progname}: {current_cam}")
+
 class FocusEnum(IntEnum):
     NEAR=0
     FAR=1
@@ -380,7 +417,11 @@ def handle_pantilt(axis: ControllerAxis=None):
     Handle motion of one of the pan/tilt axes.
     We need to set both at once, so we don't care which one moved
     """
-    global cam
+    # Phil Rose added gamepad_enabled
+    global cam, gamepad_enabled
+
+    if not gamepad_enabled:
+        return
 
     if cam is None or axis is None:
         return
@@ -405,7 +446,11 @@ def handle_zoom(axis:ControllerAxis):
     """
     Handle motion of the zoom axis
     """
-    global cam
+    # Phil rose added gamepad_enabled
+    global cam, gamepad_enabled
+
+    if not gamepad_enabled:
+        return
 
     if cam is None or axis is None:
         return
@@ -526,6 +571,64 @@ def main_loop():
                              title="Help", keep_on_top=True, line_width=70,
                              image=search_path(controller.help_image))
 
+# Phil Rose (2026-06-24)
+# Companion OSC integration help for camera-name selection and /clearcam support.
+        elif event == 'Companion Help':
+            Sg.popup_scrolled(
+                f"""{config.progname} ({config.progvers})
+
+Companion / OSC Integration
+
+The application listens for OSC messages on UDP port 9999 on 127.0.0.1
+
+Select a camera with the Generic: OSC Connection
+----------------
+OSC Path:
+/setcam
+
+Value:
+Either a camera name or a configured camera number.
+
+Examples:
+/setcam Front
+/setcam Left
+/setcam Over
+/setcam Tail
+
+or
+
+/setcam 1
+/setcam 2
+
+Selecting a camera automatically enables gamepad PTZ control.
+
+Disable PTZ control
+-------------------
+OSC Path:
+/clearcam
+
+No value is required.
+
+Example:
+/clearcam
+
+Use /clearcam when switching to a non-camera
+source such as PowerPoint, video playback,
+or screen sharing.
+
+This disables gamepad PTZ movement until
+another /setcam command is received.
+
+Tip:
+Using configured camera names (e.g. Front, Left, Over, Tail)
+is recommended instead of camera numbers, since names remain
+consistent even if camera assignments change.
+""",
+            title="Companion Help",
+            keep_on_top=True,
+            size=(80, 25)
+        )
+        
         elif event == 'Credits':
             Sg.popup(config.credits_text, title="Credits", keep_on_top=True, line_width=80)
 
@@ -547,6 +650,10 @@ def main_loop():
                 ev = values[0]
 
             pygame_lock(lambda: handle_pygame_event(ev))
+
+# Companion /clearcam support
+        elif event == "OSC_CLEAR_CAMERA":
+            pygame_lock(lambda: osc_clear_cam())
 
         elif event == "OSC_SET_CAMERA":
             pygame_lock(lambda: osc_select_cam(values['OSC_SET_CAMERA']))
@@ -643,7 +750,7 @@ def main():
                             size=output_size,
                             key='OUTPUT')
 
-    menu_def = [['Menu', ['Minimize', 'Configure', 'Help', 'Credits', 'Exit']]]
+    menu_def = [['Menu', ['Minimize', 'Configure', 'Help', 'Companion Help', 'Credits', 'Exit']]]
     layout = [[Sg.Menu(menu_def)], [output]]
 
     window = Sg.Window( title=config.progname, layout=layout,

--- a/osc.py
+++ b/osc.py
@@ -11,6 +11,9 @@ from pythonosc.osc_server import BlockingOSCUDPServer
 from win_print import win_print
 #from time import sleep
 
+# Phil Rose: allow OSC /setcam to use camera names as well as numbers.
+from config import cam_names, g_num_cams
+
 OSC_Port = 9999
 
 window : Optional[Sg.Window]  = None
@@ -19,12 +22,34 @@ def camera_handler(_address, *args):
     """ Dispatcher handler for setcam command """
     global window
 
+    if len(args) == 0:
+        win_print("OSC Set Camera: missing argument")
+        return
+
     try:
         cam_num = int(args[0])
-        window.write_event_value('OSC_SET_CAMERA', cam_num)
-
+ 
     except ValueError:
-        win_print(f"OSC Set Camera: bad arguments {args}")
+        # Phil Mod: allow /setcam "Lathe" or /setcam "Front"
+        requested_name = str(args[0]).strip().lower()
+        cam_num = None
+
+        for i in range(g_num_cams):
+            if cam_names[i].strip().lower() == requested_name:
+                cam_num = i + 1
+                break
+
+        if cam_num is None:
+            win_print(f"OSC Set Camera: unknown camera name '{args[0]}'")
+            return
+
+    window.write_event_value('OSC_SET_CAMERA', cam_num)
+
+def clear_camera_handler(_address, *args):
+    """ Disable gamepad PTZ control when no camera is active. """
+    global window
+    window.write_event_value('OSC_CLEAR_CAMERA', None)
+
 
 def osc_task(t):
     """
@@ -48,7 +73,8 @@ class OSCTask:
 
         self.dispatcher = Dispatcher()
         self.dispatcher.map("/setcam", camera_handler)
-        self.server = BlockingOSCUDPServer(('',
+        self.dispatcher.map("/clearcam", clear_camera_handler)
+        self.server = BlockingOSCUDPServer(('127.0.0.1',
                                             OSC_Port),
                                            dispatcher=self.dispatcher)
         self.thread = threading.Thread(target=self.osc_task)


### PR DESCRIPTION
This pull request adds several usability improvements for Companion integration and camera management while maintaining backward compatibility with existing configurations.

### Features

* Added configurable camera names
* Camera names are persisted across application restarts
* `/setcam` OSC command now accepts either:

  * Camera numbers (e.g. `1`)
  * Configured camera names (e.g. `Front`, `Left`, `Over`, `Tail`)
* Added `/clearcam` OSC command to disable PTZ control until another camera is selected
* Added configurable PTZ response curves for:

  * Pan
  * Tilt
  * Zoom
  * Focus
* Added validation for response profile configuration entries
* Added Companion Help documentation accessible from the application menu

### User Interface

* Reorganized the Configure dialog into logical sections
* Added camera name configuration fields
* Added response curve configuration fields and explanatory help text

### Compatibility

* Existing numeric `/setcam` commands continue to work unchanged
* Existing Companion configurations remain compatible

The response curve implementation uses the existing sensitivity tables as defaults while allowing user customization through configuration.
